### PR TITLE
Remove has_advertiser_opted_in_odax from adaccounts stream

### DIFF
--- a/tap_facebook/streams.py
+++ b/tap_facebook/streams.py
@@ -1361,7 +1361,6 @@ class AdAccountsStream(FacebookStream):
         Property("disable_reason", IntegerType),
         Property("end_advertiser", StringType),
         Property("end_advertiser_name", StringType),
-        Property("has_advertiser_opted_in_odax", BooleanType),
         Property("has_migrated_permissions", BooleanType),
         Property("id", StringType),
         Property("is_attribution_spec_system_default", BooleanType),

--- a/tap_facebook/streams.py
+++ b/tap_facebook/streams.py
@@ -1270,7 +1270,6 @@ class AdAccountsStream(FacebookStream):
         "disable_reason",
         "end_advertiser",
         "end_advertiser_name",
-        "has_advertiser_opted_in_odax",
         "has_migrated_permissions",
         "id",
         "is_attribution_spec_system_default",


### PR DESCRIPTION
Including this field causes the API to respond with a 400 Bad Request:

```python
Traceback (most recent call last):
  File "/meltano/.meltano/extractors/tap-facebook/venv/bin/tap-facebook", line 8, in <module>
    sys.exit(TapFacebook.cli())
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/tap_base.py", line 536, in cli
    tap.sync_all()
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/tap_base.py", line 426, in sync_all
    stream.sync()
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/streams/core.py", line 1162, in sync
    for _ in self._sync_records(context=context):
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/streams/core.py", line 1061, in _sync_records
    for record_result in self.get_records(current_context):
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/streams/rest.py", line 574, in get_records
    for record in self.request_records(context):
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/streams/rest.py", line 395, in request_records
    resp = decorated_request(prepared_request, context)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/backoff/_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/singer_sdk/streams/rest.py", line 274, in _request
    self.validate_response(response)
  File "/meltano/.meltano/extractors/tap-facebook/venv/lib/python3.8/site-packages/tap_facebook/client.py", line 153, in validate_response
    raise FatalAPIError(msg)
singer_sdk.exceptions.FatalAPIError: 400 Client Error: b'{"error":{"message":"(#12) Since we have ODAX enforcement from v17, this field is useless and should always be assumed true is deprecated for versions v17.0 and higher","type":"OAuthException","code":12,"fbtrace_id":"Ab3F-N9dLyiQFWSx4NEbwf3"}}' (Reason: Bad Request) for path: /v16.0/me/adaccounts
```

There is a suggested fix here but it does not always seem to work: https://github.com/MeltanoLabs/tap-facebook/issues/108.